### PR TITLE
Fix warnings

### DIFF
--- a/test/compile.sh
+++ b/test/compile.sh
@@ -1,1 +1,1 @@
-c++ -std=c++14 test.cpp -o test.out
+c++ -std=c++14 -Wshadow test.cpp -o test.out

--- a/test/compile.sh
+++ b/test/compile.sh
@@ -1,1 +1,1 @@
-c++ -std=c++14 -Wextra -Wshadow test.cpp -o test.out
+c++ -std=c++14 -Werror -Wall -Wextra -Wshadow -Wno-variadic-macros test.cpp -o test.out

--- a/test/compile.sh
+++ b/test/compile.sh
@@ -1,1 +1,1 @@
-c++ -std=c++14 -Wshadow test.cpp -o test.out
+c++ -std=c++14 -Wextra -Wshadow test.cpp -o test.out

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -29,7 +29,7 @@ void test_semantics_reset_move() {
   {
     auto cleanup = std_experimental::make_unique_resource(
         std::make_unique<int>(42),
-        [&out](auto const& i) { out << "cleaned "; });
+        [&out](auto const&) { out << "cleaned "; });
     cleanup.reset(nullptr);
   }
   assert("cleaned cleaned " == out.str());
@@ -95,7 +95,7 @@ void test_unique_resource_can_be_moved() {
   }
   assert("cleaned 42" == out.str());
 }
-void thrower(int i) noexcept(false) { throw 42; }
+void thrower(int) noexcept(false) { throw 42; }
 void test_noexcept_deleter() {
   //auto cleanup = std_experimental::make_unique_resource(42, &thrower);
   //will terminate if run....

--- a/unique_resource.hpp
+++ b/unique_resource.hpp
@@ -31,10 +31,10 @@ template <typename R, typename D> class unique_resource {
   unique_resource(unique_resource const &) = delete; // no copies!
 public:
   // construction
-  explicit unique_resource(R &&resource, D &&deleter,
+  explicit unique_resource(R &&resource_, D &&deleter_,
                            bool shouldrun = true) noexcept
-      : resource(std::move(resource)),
-        deleter(std::move(deleter)),
+      : resource(std::move(resource_)),
+        deleter(std::move(deleter_)),
         execute_on_destruction{shouldrun} {}
   // move
   unique_resource(unique_resource &&other) noexcept


### PR DESCRIPTION
This PR suppresses some warnings caused when using the header in platforms like [mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native).
